### PR TITLE
Use chaining/mixins provided by `express-context` v0.5.0.

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -20,5 +20,5 @@ module.exports = function authentication(options) {
 		properties: [ 'authentication', 'authenticated', 'challenge' ]
 	});
 
-	return _.assign(context, mixins);
+	return context.mixin(mixins);
 };

--- a/lib/mixins/failed.js
+++ b/lib/mixins/failed.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 */
 module.exports = function failed() {
 	var self = this;
-	return function check(req, res, next) {
+	return this.chain(function check(req, res, next) {
 		next(!_.some(self.of(req, true), 'authenticated') ? null : 'route');
-	};
+	});
 };

--- a/lib/mixins/required.js
+++ b/lib/mixins/required.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 */
 module.exports = function required() {
 	var self = this;
-	return function check(req, res, next) {
+	return this.chain(function check(req, res, next) {
 		if (_.some(self.of(req, true), 'authenticated')) {
 			next(null);
 		} else {
@@ -22,5 +22,5 @@ module.exports = function required() {
 				error: 'AUTHENTICATION_REQUIRED'
 			});
 		}
-	};
+	});
 };

--- a/lib/mixins/succeeded.js
+++ b/lib/mixins/succeeded.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 */
 module.exports = function succeeded() {
 	var self = this;
-	return function check(req, res, next) {
+	return this.chain(function check(req, res, next) {
 		next(_.some(self.of(req, true), 'authenticated') ? null : 'route');
-	};
+	});
 };

--- a/lib/mixins/tried.js
+++ b/lib/mixins/tried.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 */
 module.exports = function tried() {
 	var self = this;
-	return function check(req, res, next) {
+	return this.chain(function check(req, res, next) {
 		next(_.some(self.of(req, true), 'challenge') ? null : 'route');
-	};
+	});
 };

--- a/lib/mixins/untried.js
+++ b/lib/mixins/untried.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
  */
 module.exports = function untried() {
 	var self = this;
-	return function check(req, res, next) {
+	return this.chain(function check(req, res, next) {
 		next(!_.some(self.of(req, true), 'challenge') ? null : 'route');
-	};
+	});
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"express": "^4.10.2"
 	},
 	"dependencies": {
-		"express-context": "^0.3.0",
+		"express-context": "^0.5.0",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {

--- a/test/spec/mixins/failed.spec.js
+++ b/test/spec/mixins/failed.spec.js
@@ -8,7 +8,12 @@ describe('mixins', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
 			this.of = this.sandbox.stub().returns({ });
-			this.failed = failed.call({ of: this.of });
+			this.failed = failed.call({
+				of: this.of,
+				chain: function(fn) {
+					return fn;
+				}
+			});
 		});
 
 		afterEach(function() {

--- a/test/spec/mixins/required.spec.js
+++ b/test/spec/mixins/required.spec.js
@@ -9,7 +9,12 @@ describe('mixins', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
 			this.of = this.sandbox.stub().returns({ });
-			this.required = required.call({ of: this.of });
+			this.required = required.call({
+				of: this.of,
+				chain: function(fn) {
+					return fn;
+				}
+			});
 		});
 
 		afterEach(function() {

--- a/test/spec/mixins/succeeded.spec.js
+++ b/test/spec/mixins/succeeded.spec.js
@@ -9,7 +9,12 @@ describe('mixins', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
 			this.of = this.sandbox.stub().returns({ });
-			this.succeeded = succeeded.call({ of: this.of });
+			this.succeeded = succeeded.call({
+				of: this.of,
+				chain: function(fn) {
+					return fn;
+				}
+			});
 		});
 
 		afterEach(function() {

--- a/test/spec/mixins/tried.spec.js
+++ b/test/spec/mixins/tried.spec.js
@@ -8,7 +8,12 @@ describe('mixins', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
 			this.of = this.sandbox.stub().returns({ });
-			this.tried = tried.call({ of: this.of });
+			this.tried = tried.call({
+				of: this.of,
+				chain: function(fn) {
+					return fn;
+				}
+			});
 		});
 
 		afterEach(function() {

--- a/test/spec/mixins/untried.spec.js
+++ b/test/spec/mixins/untried.spec.js
@@ -8,7 +8,12 @@ describe('mixins', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
 			this.of = this.sandbox.stub().returns({ });
-			this.untried = untried.call({ of: this.of });
+			this.untried = untried.call({
+				of: this.of,
+				chain: function(fn) {
+					return fn;
+				}
+			});
 		});
 
 		afterEach(function() {


### PR DESCRIPTION
This allows for a more "fire and forget" approach to including authentication middleware. No longer do you need to use several use statements just to eke out one `auth.required()`. Everything will automatically be included for you now. Some thought needs to go into ensuring things don't get processed twice now, however.
