### PR TITLE
Update `express-context` version and fix argument mismatch.

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -15,10 +15,9 @@ module.exports = function authentication(options) {
 		context: '__authentication'
 	});
 
-	var context = contextualize({
-		name: options.name,
+	return contextualize({
+		context: options.context,
 		properties: [ 'authentication', 'authenticated', 'challenge' ]
-	});
+	}).mixin(mixins);
 
-	return context.mixin(mixins);
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"express": "^4.10.2"
 	},
 	"dependencies": {
-		"express-context": "^0.5.0",
+		"express-context": "^0.6.0",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Some options weren't being passed in correctly and there was a breaking bug in previous version of `express-context`. This addresses both.
