### PR TITLE
Simpler mixin middleware and `express-context` v0.7.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.11'

--- a/example/example.js
+++ b/example/example.js
@@ -3,12 +3,10 @@
 'use strict';
 
 var express = require('express'),
-	http = require('http'),
 	path = require('path'),
 	authentication = require(path.join(__dirname, '..'));
 
-var app = express(),
-	auth = authentication();
+var app = express();
 
 /**
  * Authentication middleware.
@@ -38,9 +36,7 @@ function secret(req, res, next) {
 	next();
 }
 
-// Create middleware sequence
-app.use(auth);
-app.use(auth.for(secret));
+var auth = authentication().for('secret').use(secret);
 
 // Simple unauthenticated route
 app.get('/', function indexRoute(req, res) {
@@ -52,14 +48,14 @@ app.get('/secret', auth.required(), function secretRoute(req, res) {
 	res.status(200).send({ message: 'secret' });
 });
 
-app.get('/other', auth.for(secret).succeeded(), function other(req, res) {
+app.get('/other', auth.succeeded(), function other(req, res) {
 	//var data = auth.for(secret).of(req);
 	res.status(200).send({ message: 'hello' });
 });
 
-app.get('/other', auth.for(secret).failed(), function other2(req, res) {
+app.get('/other', auth.failed(), function other2(req, res) {
 	res.status(400).send({ message: 'auth_fail_lelelel' });
 });
 
 // Start the server
-http.createServer(app).listen(process.env.PORT || 5553);
+app.listen(process.env.PORT || 5553);

--- a/example/multi.js
+++ b/example/multi.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var express = require('express'),
+	path = require('path'),
+	authentication = require(path.join(__dirname, '..'));
+
+var app = express(),
+	auth = authentication();
+
+auth = auth.mixin({
+	query: function query(param) {
+		return this.use(function middleware(req, res, next) {
+			req.challenge = req.query[param];
+			next();
+		});
+	},
+	check: function check(value) {
+		return this.use(function middleware(req, res, next) {
+			req.authenticated = req.challenge === value;
+			console.log('CHECKED OUT BRO!');
+			next();
+		});
+	}
+});
+
+
+var auth1 = auth.for('auth1').query('auth_code').check('secret'),
+	auth2 = auth.for('auth2').query('userid').check('bananas');
+
+// use similar chaining approach for and/or:
+// and(auth1, auth2) = parallel(auth1, auth2) + mixin(shared methods)
+// and(auth1, auth2).method() -> parallel(auth1.method(), auth2.method()) ??
+// not quite
+// and(a,b).c() -> (a,b) _MUST_ succeed, (a,c),(b,c) _MUST_ succeed
+//  or(a,b).c() -> (a,b) _MUST_ succeed, (a,c),(b,c) EITHER
+
+app.get('/a', auth1.required(), function a(req, res) {
+	res.status(200).send('Hello world.');
+});
+
+app.get('/b', auth2.required(), function b(req, res) {
+	res.status(200).send('Hello world.');
+});
+
+/*
+app.get('/aandb', both(auth1, auth2).required(), function aandb(req, res) {
+	res.status(200).send('Hello world.');
+});
+
+app.get('/aorb', either(auth1, auth2).required(), function aorb(req, res) {
+	res.status(200).send('Hello world.');
+});
+*/
+
+app.listen(process.env.PORT);

--- a/example/single.js
+++ b/example/single.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var express = require('express'),
+	path = require('path'),
+	authentication = require(path.join(__dirname, '..'));
+
+var app = express();
+
+app.use(function middleware(req, res, next) {
+	req.challenge = req.query.auth_code;
+	req.authenticated = req.challenge === 'secret';
+	next();
+});
+
+app.get('/', authentication.required(), function index(req, res) {
+	res.status(200).send('Hello world.');
+});
+
+app.listen(process.env.PORT);

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -10,14 +10,22 @@ var _ = require('lodash'),
  * @param {Object} options Configuration options.
  * @returns {Function} Middleware.
  */
-module.exports = function authentication(options) {
+module.exports = _.assign(function authentication(options) {
 	options = _.assign({ }, options, {
 		context: '__authentication'
 	});
 
-	return contextualize({
+	var context = contextualize({
 		context: options.context,
 		properties: [ 'authentication', 'authenticated', 'challenge' ]
-	}).mixin(mixins);
+	});
 
-};
+	var wrapped = _.mapValues(mixins, function wrap(mixin) {
+		return function wrapper() {
+			return this.use(mixin.apply(this, arguments));
+		};
+	});
+
+	return context.mixin(wrapped);
+
+}, mixins);

--- a/lib/mixins/failed.js
+++ b/lib/mixins/failed.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 /**
 * Description goes here.
 *
@@ -11,8 +9,7 @@ var _ = require('lodash');
 * @see
 */
 module.exports = function failed() {
-	var self = this;
-	return this.chain(function check(req, res, next) {
-		next(!_.some(self.of(req, true), 'authenticated') ? null : 'route');
-	});
+	return function check(req, res, next) {
+		next(!req.authenticated ? null : 'route');
+	};
 };

--- a/lib/mixins/required.js
+++ b/lib/mixins/required.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 /**
 * Description goes here.
 *
@@ -11,9 +9,8 @@ var _ = require('lodash');
 * @see
 */
 module.exports = function required() {
-	var self = this;
-	return this.chain(function check(req, res, next) {
-		if (_.some(self.of(req, true), 'authenticated')) {
+	return function check(req, res, next) {
+		if (req.authenticated) {
 			next(null);
 		} else {
 			next({
@@ -22,5 +19,5 @@ module.exports = function required() {
 				error: 'AUTHENTICATION_REQUIRED'
 			});
 		}
-	});
+	};
 };

--- a/lib/mixins/succeeded.js
+++ b/lib/mixins/succeeded.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 /**
 * Description goes here.
 *
@@ -11,8 +9,7 @@ var _ = require('lodash');
 * @see
 */
 module.exports = function succeeded() {
-	var self = this;
-	return this.chain(function check(req, res, next) {
-		next(_.some(self.of(req, true), 'authenticated') ? null : 'route');
-	});
+	return function check(req, res, next) {
+		next(req.authenticated ? null : 'route');
+	};
 };

--- a/lib/mixins/tried.js
+++ b/lib/mixins/tried.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 /**
 * Description goes here.
 *
@@ -11,8 +9,7 @@ var _ = require('lodash');
 * @see
 */
 module.exports = function tried() {
-	var self = this;
-	return this.chain(function check(req, res, next) {
-		next(_.some(self.of(req, true), 'challenge') ? null : 'route');
-	});
+	return function check(req, res, next) {
+		next(req.challenge ? null : 'route');
+	};
 };

--- a/lib/mixins/untried.js
+++ b/lib/mixins/untried.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 /**
  * Description goes here.
  *
@@ -11,8 +9,7 @@ var _ = require('lodash');
  * @see
  */
 module.exports = function untried() {
-	var self = this;
-	return this.chain(function check(req, res, next) {
-		next(!_.some(self.of(req, true), 'challenge') ? null : 'route');
-	});
+	return function check(req, res, next) {
+		next(!req.challenge ? null : 'route');
+	};
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"express": "^4.10.2"
 	},
 	"dependencies": {
-		"express-context": "^0.6.1",
+		"express-context": "^0.7.0",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {

--- a/test/spec/authentication.spec.js
+++ b/test/spec/authentication.spec.js
@@ -1,11 +1,113 @@
 
 'use strict';
 
-var authentication = require('authentication');
+var express = require('express'),
+	request = require('supertest'),
+	authentication = require('authentication');
 
 describe('#authenticator', function() {
 	it('should return new middleware', function() {
 		var auth = authentication();
 		expect(auth).to.not.be.null;
+	});
+
+	describe('with context', function() {
+
+		beforeEach(function() {
+			var app = this.app = express(),
+				auth = authentication();
+
+			auth = auth.mixin({
+				query: function query(param) {
+					return this.use(function middleware(req, res, next) {
+						req.challenge = req.query[param];
+						next();
+					});
+				},
+				check: function check(value) {
+					return this.use(function middleware(req, res, next) {
+						req.authenticated = req.challenge === value;
+						next();
+					});
+				}
+			});
+
+
+			var auth1 = auth.for('auth1').query('code').check('secret');
+
+			app.get('/', auth1.required(), function a(req, res) {
+				res.status(200).send('Hello world.');
+			});
+		});
+
+		it('should work when authentication succeeds', function(done) {
+			request(this.app)
+				.get('/')
+				.query({ code: 'secret' })
+				.expect(function(res) {
+					expect(res.statusCode).to.equal(200);
+				})
+				.end(done);
+		});
+
+		it('should work when authentication fails', function(done) {
+			request(this.app)
+				.get('/')
+				.query({ code: 'fail' })
+				.expect(function(res) {
+					expect(res.statusCode).to.equal(401);
+				})
+				.end(done);
+		});
+	});
+
+	describe('without context', function() {
+
+		beforeEach(function() {
+			var app = this.app = express();
+
+			function query(param) {
+				return function middleware(req, res, next) {
+					req.challenge = req.query[param];
+					next();
+				};
+			}
+
+			function check(value) {
+				return function middleware(req, res, next) {
+					req.authenticated = req.challenge === value;
+					next();
+				};
+			}
+
+			app.get('/',
+				query('code'),
+				check('secret'),
+				authentication.required(),
+				function a(req, res) {
+					res.status(200).send('Hello world.');
+				}
+			);
+		});
+
+		it('should work when authentication succeeds', function(done) {
+			request(this.app)
+				.get('/')
+				.query({ code: 'secret' })
+				.expect(function(res) {
+					expect(res.statusCode).to.equal(200);
+				})
+				.end(done);
+		});
+
+		it('should work when authentication fails', function(done) {
+			request(this.app)
+				.get('/')
+				.query({ code: 'fail' })
+				.expect(function(res) {
+					expect(res.statusCode).to.equal(401);
+				})
+				.end(done);
+		});
 	});
 });

--- a/test/spec/mixins/failed.spec.js
+++ b/test/spec/mixins/failed.spec.js
@@ -7,36 +7,21 @@ describe('mixins', function() {
 
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.of = this.sandbox.stub().returns({ });
-			this.failed = failed.call({
-				of: this.of,
-				chain: function(fn) {
-					return fn;
-				}
-			});
 		});
 
 		afterEach(function() {
 			this.sandbox.restore();
 		});
 
-		it('should continue if all authenticated is false', function() {
+		it('should continue if authenticated is false', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: false }
-			});
-			this.failed(null, null, next);
+			failed()({ authenticated: false }, null, next);
 			expect(next).to.be.calledWith(null);
 		});
 
-		it('should next route if any authenticated is true', function() {
+		it('should next route if authenticated is true', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: true }
-			});
-			this.failed(null, null, next);
+			failed()({ authenticated: true }, null, next);
 			expect(next).to.be.calledWith('route');
 		});
 

--- a/test/spec/mixins/required.spec.js
+++ b/test/spec/mixins/required.spec.js
@@ -8,36 +8,21 @@ describe('mixins', function() {
 
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.of = this.sandbox.stub().returns({ });
-			this.required = required.call({
-				of: this.of,
-				chain: function(fn) {
-					return fn;
-				}
-			});
 		});
 
 		afterEach(function() {
 			this.sandbox.restore();
 		});
 
-		it('should continue if any authenticated is true', function() {
+		it('should continue if authenticated is true', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: true }
-			});
-			this.required(null, null, next);
+			required()({ authenticated: true }, null, next);
 			expect(next).to.be.calledWith(null);
 		});
 
-		it('should error if all authenticated is false', function() {
+		it('should error if authenticated is false', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: false }
-			});
-			this.required(null, null, next);
+			required()({ authenticated: false }, null, next);
 			expect(next).to.be.calledWithMatch({ statusCode: 401 });
 		});
 

--- a/test/spec/mixins/succeeded.spec.js
+++ b/test/spec/mixins/succeeded.spec.js
@@ -8,36 +8,21 @@ describe('mixins', function() {
 
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.of = this.sandbox.stub().returns({ });
-			this.succeeded = succeeded.call({
-				of: this.of,
-				chain: function(fn) {
-					return fn;
-				}
-			});
 		});
 
 		afterEach(function() {
 			this.sandbox.restore();
 		});
 
-		it('should continue if any authenticated is true', function() {
+		it('should continue if authenticated is true', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: true }
-			});
-			this.succeeded(null, null, next);
+			succeeded()({ authenticated: true }, null, next);
 			expect(next).to.be.calledWith(null);
 		});
 
-		it('should next route if all authenticated is false', function() {
+		it('should next route if authenticated is false', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { authenticated: false },
-				b: { authenticated: false }
-			});
-			this.succeeded(null, null, next);
+			succeeded()({ authenticated: false }, null, next);
 			expect(next).to.be.calledWith('route');
 		});
 

--- a/test/spec/mixins/tried.spec.js
+++ b/test/spec/mixins/tried.spec.js
@@ -7,36 +7,21 @@ describe('mixins', function() {
 	describe('#tried', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.of = this.sandbox.stub().returns({ });
-			this.tried = tried.call({
-				of: this.of,
-				chain: function(fn) {
-					return fn;
-				}
-			});
 		});
 
 		afterEach(function() {
 			this.sandbox.restore();
 		});
 
-		it('should return true if any challenge is true', function() {
+		it('should return true if challenge is true', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { challenge: false },
-				b: { challenge: true }
-			});
-			this.tried(null, null, next);
+			tried()({ challenge: true }, null, next);
 			expect(next).to.be.calledWith(null);
 		});
 
-		it('should return false if all challenge is false', function() {
+		it('should return false if challenge is false', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { challenge: false },
-				b: { challenge: false }
-			});
-			this.tried(null, null, next);
+			tried()({ challenge: false }, null, next);
 			expect(next).to.be.calledWith('route');
 		});
 	});

--- a/test/spec/mixins/untried.spec.js
+++ b/test/spec/mixins/untried.spec.js
@@ -7,36 +7,21 @@ describe('mixins', function() {
 	describe('#untried', function() {
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.of = this.sandbox.stub().returns({ });
-			this.untried = untried.call({
-				of: this.of,
-				chain: function(fn) {
-					return fn;
-				}
-			});
 		});
 
 		afterEach(function() {
 			this.sandbox.restore();
 		});
 
-		it('should return true if all challenge is false', function() {
+		it('should return true if challenge is false', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { challenge: false },
-				b: { challenge: false }
-			});
-			this.untried(null, null, next);
+			untried()({ challenge: false }, null, next);
 			expect(next).to.be.calledWith(null);
 		});
 
-		it('should return false if any challenge is true', function() {
+		it('should return false if challenge is true', function() {
 			var next = this.sandbox.stub();
-			this.of.returns({
-				a: { challenge: false },
-				b: { challenge: true }
-			});
-			this.untried(null, null, next);
+			untried()({ challenge: true }, null, next);
 			expect(next).to.be.calledWith('route');
 		});
 	});


### PR DESCRIPTION
This allows mixins to be used standalone without any kind of context, making `express-authentication` useful even without involving any context at all.

Updates `express-context` to the latest version to ensure features are compatible.

Adds more complete end-to-end tests for using all the mixins together.