### PR TITLE
Accept error from user's middleware

### DIFF
--- a/lib/mixins/required.js
+++ b/lib/mixins/required.js
@@ -9,11 +9,11 @@
 * @see
 */
 module.exports = function required() {
-	return function check(req, res, next) {
+	return function check(error, req, res, next) {
 		if (req.authenticated) {
 			next(null);
 		} else {
-			next({
+			next(error || {
 				status: 401,
 				statusCode: 401,
 				error: 'AUTHENTICATION_REQUIRED'


### PR DESCRIPTION
If user does `next(error here)` then `required()` will pass that along instead of it's canned error.