### PR TITLE
Add customizable authentication errors.

### DIFF
--- a/lib/mixins/required.js
+++ b/lib/mixins/required.js
@@ -1,23 +1,38 @@
 
 'use strict';
 
+var _ = require('lodash');
+
 /**
 * Description goes here.
-*
+* @param {Object|Function} error Error to pass to `next` when unauthenticated.
 * @returns {Function} Middleware.
-*
-* @see
 */
-module.exports = function required() {
-	return function check(req, res, next) {
-		if (req.authenticated) {
-			next(null);
-		} else {
-			next({
-				status: 401,
-				statusCode: 401,
-				error: 'AUTHENTICATION_REQUIRED'
-			});
-		}
-	};
+module.exports = function required(error) {
+	if (!(error)) {
+		error = {
+			status: 401,
+			statusCode: 401,
+			error: 'AUTHENTICATION_REQUIRED'
+		};
+	}
+	if (_.isFunction(error)) {
+		return function check(req, res, next) {
+			if (req.authenticated) {
+				next(null);
+			} else {
+				next(error(req, res));
+			}
+		};
+	} else if (_.isObject(error)) {
+		return function check(req, res, next) {
+			if (req.authenticated) {
+				next(null);
+			} else {
+				next(error);
+			}
+		};
+	} else {
+		throw new TypeError();
+	}
 };

--- a/test/spec/mixins/required.spec.js
+++ b/test/spec/mixins/required.spec.js
@@ -26,5 +26,33 @@ describe('mixins', function() {
 			expect(next).to.be.calledWithMatch({ statusCode: 401 });
 		});
 
+		it('should accept an error object', function() {
+			var next = this.sandbox.stub();
+			required({ statusCode: 403 })({ authenticated: false }, null, next);
+			expect(next).to.be.calledWithMatch({ statusCode: 403 });
+		});
+
+		it('should use the result of an error function', function() {
+			var next = this.sandbox.stub();
+			required(function() {
+				return { statusCode: 403 };
+			})({ authenticated: false }, null, next);
+			expect(next).to.be.calledWithMatch({ statusCode: 403 });
+		});
+
+		it('should skip error function when authenticated', function() {
+			var next = this.sandbox.stub();
+			required(function() {
+				return { statusCode: 403 };
+			})({ authenticated: true }, null, next);
+			expect(next).to.be.calledWith(null);
+		});
+
+		it('should fail on invalid arguments', function() {
+			expect(function() {
+				required('foo');
+			}).to.throw(TypeError);
+		});
+
 	});
 });


### PR DESCRIPTION
When using the `required` mixin the default error object may not be useful enough, so now it's customizable either via object literal or function that returns an error object. Usage:

```javascript
// literal
required({
	custom: 'error'
});

// function
required(function() {
	return {
		custom: 'error'
	};
});
```