### PR TITLE
Add global `.of` method.

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -28,4 +28,8 @@ module.exports = _.assign(function authentication(options) {
 
 	return context.mixin(wrapped);
 
-}, mixins);
+}, mixins, {
+	of: function pick(req) {
+		return _.pick(req, 'authentication', 'authenticated', 'challenge');
+	}
+});


### PR DESCRIPTION
Ideally `express-context` should have a method for incorporating this, but for now this just provides some encapsulation for returning all the relevant authentication data when NOT using a context. The equivalent contextualized function goes by the same name and does the same thing.
